### PR TITLE
fix Changes to comply w/CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Perl module WebService::PayPal::NVP
 
-0.02 2013-09-26
+0.002 2013-09-26
 
-0.01 2013-09-23
+0.001 2013-09-23
  - First version, released on an unsuspecting world.


### PR DESCRIPTION
Hi,

I've reformatted your Changes file according to the spec in `CPAN::Changes::Spec`. The date for the first release was missing, I got it from [BackPan](http://backpan.perl.org/).

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org), which is where I saw your module listed :-)

Cheers,
Sergey

PS: I'm doing this because I'm on a quest to help improve CPAN.

> http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086

Read more about the quest at [Questhub](http://questhub.io).

If you decide to update [your other dists](http://changes.cpanhq.org/author/BRADH), feel free to log them in comments on the quest -- every dist helps!
