### PR TITLE
Expose UserAgent to users

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl module WebService::PayPal::NVP
 
+ - Allow a custom UserAgent to be provided to constructor (Olaf Alders)
+
 0.003 2015-10-01
  - Using ExtUtils::MakeMaker now
  - Converted readme to markdown

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,5 +18,15 @@ WriteMakefile(
         'URI::Escape'       => 0,
         'DateTime'          => 0,
         'YAML::Syck'        => 0,
-    },        
+    },
+    META_MERGE => {
+        'meta-spec' => { version => 2 },
+         resources => {
+             repository => {
+                 type => 'git',
+                 url  => 'https://github.com/bradhaywood/WebService-PayPal-NVP.git',
+                 web  => 'https://github.com/bradhaywood/WebService-PayPal-NVP',
+             },
+         },
+    },
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,17 +7,19 @@ WriteMakefile(
     ABSTRACT        => 'PayPal Name-Value-Pair API',
     CONFIGURE_REQUIRES => { 'ExtUtils::MakeMaker' => 0, },
     DISTNAME        => 'WebService-PayPal-NVP',
-    TEST_REQUIRES   => {
-        'Test::More' => 0,
-        'YAML::Syck' => 0,
+    TEST_REQUIRES => {
+        'Test::More'             => 0,
+        'Test::RequiresInternet' => 0.04,
+        'YAML::Syck'             => 0,
     },
     LICENSE         => 'perl_5',
-    PREREQ_PM       => {
-        'Moo'               => 0,
-        'LWP::UserAgent'    => 0,
-        'URI::Escape'       => 0,
-        'DateTime'          => 0,
-        'YAML::Syck'        => 0,
+    PREREQ_PM => {
+        'Moo'                          => 0,
+        'LWP::UserAgent'               => 0,
+        'MooX::Types::MooseLike::Base' => 0.27,
+        'URI::Escape'                  => 0,
+        'DateTime'                     => 0,
+        'YAML::Syck'                   => 0,
     },
     META_MERGE => {
         'meta-spec' => { version => 2 },

--- a/sample-auth.yml
+++ b/sample-auth.yml
@@ -1,0 +1,4 @@
+user: foo
+pass: seekrit
+sig: evenmoreseekrit
+branch: sandbox


### PR DESCRIPTION
I find myself needing to mock some functionality in a test environment where I don't want to make any calls via the network.  Allowing a custom UserAgent would allow for easier mocking.