### PR TITLE
Use UserAgent directly for POST requests (Olaf Alders)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,8 @@
 Revision history for Perl module WebService::PayPal::NVP
 
  - Fix response parsing to decode all data UTF-8 (Dave Rolsky)
-
+ - Use UserAgent directly for POST requests (Olaf Alders)
+ 
 0.004 2015-02-23
  - Allow a custom UserAgent to be provided to constructor (Olaf Alders)
  - Add get_recurring_payments_profile_details() method (Olaf Alders)

--- a/lib/WebService/PayPal/NVP.pm
+++ b/lib/WebService/PayPal/NVP.pm
@@ -56,9 +56,6 @@ sub _build_ua {
 sub _do_request {
     my ($self, $args) = @_;
 
-    my $req = HTTP::Request->new(POST => $self->url);
-    $req->content_type('application/x-www-form-urlencoded');
-
     my $authargs = {
         user      => $self->user,
         pwd       => $self->pwd,
@@ -69,8 +66,11 @@ sub _do_request {
 
     my $allargs = { %$authargs, %$args };
     my $content = $self->_build_content( $allargs );
-    $req->content($content);
-    my $res = $self->ua->request($req);
+    my $res = $self->ua->post(
+        $self->url,
+        'Content-Type' => 'application/x-www-form-urlencoded',
+        Content        => $content,
+    );
 
     unless ($res->code == 200) {
         $self->errors(["Failure: " . $res->code . ": " . $res->message]);


### PR DESCRIPTION
I was trying to observe the POST output via `LWP::ConsoleLogger::Easy` but was not able to since the POST was created via `HTTP::Request`.

This should be the equivalent syntax (works for me) and it just uses the UserAgent directly.
