### PR TITLE
Call decode on URI-unescaped k/v values

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl module WebService::PayPal::NVP
 
+ - Fix response parsing to decode all data UTF-8 (Dave Rolsky)
+
 0.004 2015-02-23
  - Allow a custom UserAgent to be provided to constructor (Olaf Alders)
  - Add get_recurring_payments_profile_details() method (Olaf Alders)

--- a/lib/WebService/PayPal/NVP.pm
+++ b/lib/WebService/PayPal/NVP.pm
@@ -2,6 +2,7 @@ package WebService::PayPal::NVP;
 
 use Moo;
 use DateTime;
+use Encode qw( decode );
 use LWP::UserAgent ();
 use MooX::Types::MooseLike::Base qw( InstanceOf );
 use URI::Escape qw/uri_escape uri_escape_utf8 uri_unescape/;
@@ -76,7 +77,7 @@ sub _do_request {
         return;
     }
 
-    my $resp = { map { uri_unescape($_) }
+    my $resp = { map { decode( 'UTF-8', uri_unescape($_) ) }
         map { split '=', $_, 2 }
             split '&', $res->content };
 


### PR DESCRIPTION
PayPal explicitly says that the content it returns will be in UTF-8. If we
don't decode it properly and just return it to the user as bytes it can end up
getting corrupted very easily.